### PR TITLE
feat: Reset mock analytics data to zero

### DIFF
--- a/src/components/Analytics.tsx
+++ b/src/components/Analytics.tsx
@@ -18,28 +18,28 @@ const Analytics = () => {
     // Simular dados de analytics
     const mockData: AnalyticsData = {
       pageViews: [
-        { name: 'Início', views: 1250 },
-        { name: 'Portfólio', views: 890 },
-        { name: 'Sobre', views: 650 },
-        { name: 'Contato', views: 430 },
+        { name: 'Início', views: 0 },
+        { name: 'Portfólio', views: 0 },
+        { name: 'Sobre', views: 0 },
+        { name: 'Contato', views: 0 },
       ],
       userStats: {
-        visitors: 2847,
-        newUsers: 1654,
-        avgTime: '3:42'
+        visitors: 0,
+        newUsers: 0,
+        avgTime: '0:00'
       },
       deviceStats: [
-        { name: 'Desktop', value: 45, color: '#8B5CF6' },
-        { name: 'Mobile', value: 40, color: '#F97316' },
-        { name: 'Tablet', value: 15, color: '#10B981' },
+        { name: 'Desktop', value: 0, color: '#8B5CF6' },
+        { name: 'Mobile', value: 0, color: '#F97316' },
+        { name: 'Tablet', value: 0, color: '#10B981' },
       ],
       monthlyViews: [
-        { month: 'Jan', views: 800 },
-        { month: 'Fev', views: 950 },
-        { month: 'Mar', views: 1200 },
-        { month: 'Abr', views: 1100 },
-        { month: 'Mai', views: 1400 },
-        { month: 'Jun', views: 1650 },
+        { month: 'Jan', views: 0 },
+        { month: 'Fev', views: 0 },
+        { month: 'Mar', views: 0 },
+        { month: 'Abr', views: 0 },
+        { month: 'Mai', views: 0 },
+        { month: 'Jun', views: 0 },
       ]
     };
 

--- a/src/components/admin/Analytics.tsx
+++ b/src/components/admin/Analytics.tsx
@@ -7,27 +7,27 @@ const Analytics = () => {
   const stats = [
     {
       title: 'Visualizações Totais',
-      value: '12,543',
+      value: '0',
       icon: Eye,
-      trend: '+12.5%'
+      trend: '0%'
     },
     {
       title: 'Visitantes Únicos',
-      value: '8,234',
+      value: '0',
       icon: Users,
-      trend: '+8.2%'
+      trend: '0%'
     },
     {
       title: 'Posts do Blog',
-      value: '45',
+      value: '0',
       icon: BarChart3,
-      trend: '+3 este mês'
+      trend: '-'
     },
     {
       title: 'Crescimento',
-      value: '23.1%',
+      value: '0%',
       icon: TrendingUp,
-      trend: '+2.4%'
+      trend: '0%'
     }
   ];
 
@@ -65,9 +65,9 @@ const Analytics = () => {
           <CardContent>
             <div className="space-y-4">
               {[
-                { title: 'Tendências de Design 2024', views: '2,543' },
-                { title: 'Guia de UX/UI', views: '1,832' },
-                { title: 'Cores e Tipografia', views: '1,234' }
+                { title: 'Tendências de Design 2024', views: '0' },
+                { title: 'Guia de UX/UI', views: '0' },
+                { title: 'Cores e Tipografia', views: '0' }
               ].map((post, index) => (
                 <div key={index} className="flex justify-between items-center">
                   <span className="text-gray-300">{post.title}</span>


### PR DESCRIPTION
Resets the placeholder analytics data in both the public-facing and admin components to zero or neutral values.

- Modified `src/components/Analytics.tsx` to set all numerical values in `mockData` to 0 and string representations to empty/zero states.
- Modified `src/components/admin/Analytics.tsx` to set numerical values in the `stats` array and 'Posts Mais Populares' data to '0' and trends to neutral values.

This addresses your request to 'Zere os status dos analytics' by updating the current mock/demonstration data. I clarified with you that a real analytics system would require a different implementation for data management and reset.