### PR TITLE
feat: Remove Social Feed section

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -11,7 +11,7 @@ import ChatBot from '@/components/ChatBot';
 import VoiceCommands from '@/components/VoiceCommands';
 import Blog from '@/components/Blog';
 import NewsletterSignup from '@/components/NewsletterSignup';
-import SocialFeed from '@/components/SocialFeed';
+// import SocialFeed from '@/components/SocialFeed'; // Removed import
 import SEOHead from '@/components/SEOHead';
 import { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
@@ -52,7 +52,7 @@ const Index = () => {
     },
     onSwipeLeft: () => {
       // Ir para próxima seção
-      const sections = ['hero', 'about', 'portfolio', 'blog', 'social', 'contact'];
+      const sections = ['hero', 'about', 'portfolio', 'blog', 'contact'];
       const currentSection = getCurrentSection();
       const currentIndex = sections.indexOf(currentSection);
       const nextIndex = (currentIndex + 1) % sections.length;
@@ -60,7 +60,7 @@ const Index = () => {
     },
     onSwipeRight: () => {
       // Ir para seção anterior
-      const sections = ['hero', 'about', 'portfolio', 'blog', 'social', 'contact'];
+      const sections = ['hero', 'about', 'portfolio', 'blog', 'contact'];
       const currentSection = getCurrentSection();
       const currentIndex = sections.indexOf(currentSection);
       const prevIndex = (currentIndex - 1 + sections.length) % sections.length;
@@ -69,7 +69,7 @@ const Index = () => {
   });
 
   const getCurrentSection = () => {
-    const sections = ['hero', 'about', 'portfolio', 'blog', 'social', 'contact'];
+    const sections = ['hero', 'about', 'portfolio', 'blog', 'contact'];
     const scrollPosition = window.scrollY + window.innerHeight / 2;
     
     for (const section of sections) {
@@ -175,9 +175,9 @@ const Index = () => {
             isAdmin={isAdminLoggedIn}
             onEditPost={handleEditPost}
           />
-          <div id="social">
+          {/* <div id="social">
             <SocialFeed />
-          </div>
+          </div> */} {/* Removed SocialFeed component rendering */}
           <div className="py-20 px-4 bg-vizualiza-bg-dark">
             <div className="max-w-4xl mx-auto">
               <NewsletterSignup />


### PR DESCRIPTION
Removes the 'Nossas Redes Sociais' (Social Feed) section from the website as per your request.

- Commented out the import and rendering of the `SocialFeed` component in `src/pages/Index.tsx`.
- Updated the `sections` arrays in the `useGestures` hook (for swipe navigation) and the `getCurrentSection` function in `src/pages/Index.tsx` to remove references to the 'social' section.
- No changes were needed in `Navbar.tsx` as there was no direct navigation link to this section.